### PR TITLE
Mirror policies from HashiCorp organisation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
+
+Please read the full text at https://www.hashicorp.com/community-guidelines

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
+
+If you would like to report a vulnerability in one of our products, or have security concerns regarding HashiCorp software, please email [security@hashicorp.com](mailto:security@hashicorp.com).
+
+In order for us to best respond to your report, please include any of the following:
+
+* Steps to reproduce or proof-of-concept
+* Any relevant tools, including versions used
+* Tool output
+
+For additional information about HashiCorp security, please see [https://hashicorp.com/security](https://hashicorp.com/security).


### PR DESCRIPTION
## Overview

This pull-request brings over policies from the HashiCorp organisation into HashiCorp Forge to ensure consistency.